### PR TITLE
Pull Request to add release date to stories if present

### DIFF
--- a/lib/lita/handlers/rally.rb
+++ b/lib/lita/handlers/rally.rb
@@ -64,6 +64,7 @@ module Lita
           link_path: 'userstory',
           extra_output: [
             'ScheduleState',
+            ['Release', '_refObjectName'],
             ['Parent', '_refObjectName'],
             ['Feature', '_refObjectName'],
           ]


### PR DESCRIPTION
Using lita-rally with skybot. Defects currently have release date, but user stories do not. I have made the change to add release dates to user stories if they exist and request that these changes be merged into the gem. Thanks!
